### PR TITLE
[xrt_cxxwrap] fixes for xrt 2.23 and windows

### DIFF
--- a/deps/xrt_cxxwrap/CMakeLists.txt
+++ b/deps/xrt_cxxwrap/CMakeLists.txt
@@ -50,8 +50,12 @@ if (EXISTS ${XILINX_XRT}/lib64)
   target_link_directories(xrtwrap PRIVATE ${XILINX_XRT}/lib64)
 endif ()
 
+# cxxwrap_julia_stl carries the jlcxx::stl wrappers (StlWrappers::instance et al.)
+# that jlcxx/stl.hpp uses to wrap std::deque etc. Linux shared libs resolve it
+# lazily at load time, but the Windows DLL link needs it named explicitly.
 target_link_libraries(xrtwrap PRIVATE
   JlCxx::cxxwrap_julia
+  JlCxx::cxxwrap_julia_stl
   xrt_coreutil
 )
 

--- a/deps/xrt_cxxwrap/CMakeLists.txt
+++ b/deps/xrt_cxxwrap/CMakeLists.txt
@@ -12,7 +12,7 @@ message(STATUS "Found JlCxx at ${JlCxx_location}")
 if (NOT EXISTS ${XILINX_XRT})
   message(FATAL_ERROR "Xilinx XRT not found, make sure to source setup.sh")
 endif ()
-if (NOT EXISTS ${LIB_UUID_DIR})
+if (NOT WIN32 AND NOT EXISTS ${LIB_UUID_DIR})
   message(FATAL_ERROR "No path to libuuid directory given!")
 endif ()
 if (NOT EXISTS ${LIB_BOOST_DIR})
@@ -27,28 +27,47 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${LIB_BOOST_DIR}/lib")
 
 add_library(xrtwrap SHARED ${CMAKE_SOURCE_DIR}/src/xrtwrap.cpp)
 
+if (WIN32)
+  # XRT's Windows headers (e.g. xrt_elf.h) carry inline definitions of functions
+  # marked dllimport, which GCC rejects. XRT_API_SOURCE switches XRT's API macros
+  # to their dllexport form, matching how XRT itself is compiled for Windows.
+  target_compile_definitions(xrtwrap PRIVATE _WINDOWS XRT_API_SOURCE)
+  target_compile_options(xrtwrap PRIVATE -fpermissive)
+endif ()
+
 # XRT >= 2.20 relocated its public headers from ${XILINX_XRT}/include/{experimental,
 # version.h} down into ${XILINX_XRT}/include/xrt/. Keep the flat include root for
 # older XRT and add the nested one for newer XRT; the layout that doesn't exist for
 # a given XRT install just contributes nothing.
-target_include_directories(xrtwrap PRIVATE ${XILINX_XRT}/include ${LIB_UUID_DIR}/include ${LIB_BOOST_DIR}/include)
+target_include_directories(xrtwrap PRIVATE ${XILINX_XRT}/include ${LIB_BOOST_DIR}/include)
 if (EXISTS ${XILINX_XRT}/include/xrt)
   target_include_directories(xrtwrap PRIVATE ${XILINX_XRT}/include/xrt)
 endif ()
 
 # Newer XRT packages install the runtime libraries under lib64 rather than lib.
-target_link_directories(xrtwrap PRIVATE ${XILINX_XRT}/lib ${LIB_UUID_DIR}/lib ${LIB_BOOST_DIR}/lib)
+target_link_directories(xrtwrap PRIVATE ${XILINX_XRT}/lib ${LIB_BOOST_DIR}/lib)
 if (EXISTS ${XILINX_XRT}/lib64)
   target_link_directories(xrtwrap PRIVATE ${XILINX_XRT}/lib64)
 endif ()
 
 target_link_libraries(xrtwrap PRIVATE
   JlCxx::cxxwrap_julia
-  uuid
   xrt_coreutil
 )
 
+# libuuid is Linux-only: XRT's xrt_uuid.h pulls in <uuid/uuid.h> there, whereas on
+# Windows XRT uses the OS RPC UUID facilities and no libuuid exists.
+if (NOT WIN32)
+  target_include_directories(xrtwrap PRIVATE ${LIB_UUID_DIR}/include)
+  target_link_directories(xrtwrap PRIVATE ${LIB_UUID_DIR}/lib)
+  target_link_libraries(xrtwrap PRIVATE uuid)
+endif ()
+
 set_property(TARGET xrtwrap PROPERTY POSITION_INDEPENDENT_CODE ON)
-set_property(TARGET xrtwrap PROPERTY SUFFIX ".so.${XRT_VERSION_NUMBER}")
+# On Linux, XRT.jl loads the wrapper by a versioned name (libxrtwrap.so.<ver>).
+# On Windows, keep the native libxrtwrap.dll so the JLL's LibraryProduct finds it.
+if (NOT WIN32)
+  set_property(TARGET xrtwrap PROPERTY SUFFIX ".so.${XRT_VERSION_NUMBER}")
+endif ()
 
 install(TARGETS xrtwrap DESTINATION lib)

--- a/deps/xrt_cxxwrap/CMakeLists.txt
+++ b/deps/xrt_cxxwrap/CMakeLists.txt
@@ -27,9 +27,20 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_RPATH};${LIB_BOOST_DIR}/lib")
 
 add_library(xrtwrap SHARED ${CMAKE_SOURCE_DIR}/src/xrtwrap.cpp)
 
+# XRT >= 2.20 relocated its public headers from ${XILINX_XRT}/include/{experimental,
+# version.h} down into ${XILINX_XRT}/include/xrt/. Keep the flat include root for
+# older XRT and add the nested one for newer XRT; the layout that doesn't exist for
+# a given XRT install just contributes nothing.
 target_include_directories(xrtwrap PRIVATE ${XILINX_XRT}/include ${LIB_UUID_DIR}/include ${LIB_BOOST_DIR}/include)
+if (EXISTS ${XILINX_XRT}/include/xrt)
+  target_include_directories(xrtwrap PRIVATE ${XILINX_XRT}/include/xrt)
+endif ()
 
+# Newer XRT packages install the runtime libraries under lib64 rather than lib.
 target_link_directories(xrtwrap PRIVATE ${XILINX_XRT}/lib ${LIB_UUID_DIR}/lib ${LIB_BOOST_DIR}/lib)
+if (EXISTS ${XILINX_XRT}/lib64)
+  target_link_directories(xrtwrap PRIVATE ${XILINX_XRT}/lib64)
+endif ()
 
 target_link_libraries(xrtwrap PRIVATE
   JlCxx::cxxwrap_julia

--- a/deps/xrt_cxxwrap/CMakeLists.txt
+++ b/deps/xrt_cxxwrap/CMakeLists.txt
@@ -74,4 +74,9 @@ if (NOT WIN32)
   set_property(TARGET xrtwrap PROPERTY SUFFIX ".so.${XRT_VERSION_NUMBER}")
 endif ()
 
-install(TARGETS xrtwrap DESTINATION lib)
+# Split by artifact type so the Windows runtime DLL lands in bin (where the JLL
+# convention wants it) while the import lib stays in lib; the Linux .so stays in lib.
+install(TARGETS xrtwrap
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)

--- a/deps/xrt_cxxwrap/src/xrtwrap.cpp
+++ b/deps/xrt_cxxwrap/src/xrtwrap.cpp
@@ -6,14 +6,21 @@
 #include "experimental/xrt_message.h"
 #include "jlcxx/jlcxx.hpp"
 #include "jlcxx/stl.hpp"
-// XRT >= 2.20 moved the version header from a bare `${XILINX_XRT}/include/version.h`
-// down to `${XILINX_XRT}/include/xrt/detail/version.h`. We can't branch on
-// XRT_VERSION_CODE here -- that macro is *defined by* this very header -- so probe
-// the layout with __has_include (both include roots are on the search path).
-#if __has_include("version.h")
-#include "version.h"          // XRT < 2.20 (flat include/ layout)
+// We need only XRT's version macros (XRT_VERSION_CODE / XRT_MAJOR / XRT_MINOR)
+// and the xrt_build_version string. Their home has shifted across releases:
+//   * XRT >= ~2.24: xrt/detail/version-slim.h. Prefer it -- the full version.h
+//     also pulls in a generated xrt/detail/version-git.h that XRT does NOT
+//     install, so including version.h there fails to compile.
+//   * XRT 2.20..2.23: xrt/detail/version.h (self-contained).
+//   * XRT < 2.20: a bare version.h in the flat include root.
+// We can't branch on XRT_VERSION_CODE (these headers define it), so probe the
+// layout with __has_include; every XRT include root is on the search path.
+#if __has_include("xrt/detail/version-slim.h")
+#include "xrt/detail/version-slim.h"
+#elif __has_include("version.h")
+#include "version.h"
 #else
-#include "detail/version.h"   // XRT >= 2.20 (headers nested under include/xrt/)
+#include "xrt/detail/version.h"
 #endif
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"

--- a/deps/xrt_cxxwrap/src/xrtwrap.cpp
+++ b/deps/xrt_cxxwrap/src/xrtwrap.cpp
@@ -6,7 +6,15 @@
 #include "experimental/xrt_message.h"
 #include "jlcxx/jlcxx.hpp"
 #include "jlcxx/stl.hpp"
-#include "version.h"
+// XRT >= 2.20 moved the version header from a bare `${XILINX_XRT}/include/version.h`
+// down to `${XILINX_XRT}/include/xrt/detail/version.h`. We can't branch on
+// XRT_VERSION_CODE here -- that macro is *defined by* this very header -- so probe
+// the layout with __has_include (both include roots are on the search path).
+#if __has_include("version.h")
+#include "version.h"          // XRT < 2.20 (flat include/ layout)
+#else
+#include "detail/version.h"   // XRT >= 2.20 (headers nested under include/xrt/)
+#endif
 #include "xrt/xrt_bo.h"
 #include "xrt/xrt_device.h"
 #include "xrt/xrt_kernel.h"


### PR DESCRIPTION
Fix up the xrt_cxxwrap wrapper library in preparation for building as a jll (#3).

Written by claude, but I reviewed and tested all the changes and they seemed sensible.